### PR TITLE
Add storage map page

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,10 +184,10 @@
                 <div class="bg-white p-6 rounded-lg custom-shadow">
                     <h2 class="text-xl font-bold text-gray-800 mb-4">クイックアクション</h2>
                     <div class="space-y-3">
-                        <button class="w-full bg-blue-50 text-blue-700 p-3 rounded-lg hover:bg-blue-100 transition text-left">
+                        <a href="map.html" class="block w-full bg-blue-50 text-blue-700 p-3 rounded-lg hover:bg-blue-100 transition text-left">
                             <i class="fas fa-map mr-3"></i>
                             収納マップ
-                        </button>
+                        </a>
                         <button class="w-full bg-purple-50 text-purple-700 p-3 rounded-lg hover:bg-purple-100 transition text-left">
                             <i class="fas fa-tags mr-3"></i>
                             QRコード管理

--- a/map.html
+++ b/map.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>収納マップ - どこに置いたっけ？</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <style>
+        body { background: #f5f7fa; }
+    </style>
+</head>
+<body class="p-6">
+    <header class="mb-6">
+        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
+        <h1 class="text-2xl font-bold mt-2">収納マップ</h1>
+    </header>
+    <div id="mapContainer" class="space-y-4"></div>
+    <script src="script.js"></script>
+    <script>
+        function renderMap() {
+            const container = document.getElementById('mapContainer');
+            const items = loadItems();
+            if (items.length === 0) {
+                container.innerHTML = '<p class="text-gray-600">まだアイテムが登録されていません。</p>';
+                return;
+            }
+            const map = {};
+            items.forEach(item => {
+                if (!map[item.parent]) map[item.parent] = {};
+                if (!map[item.parent][item.detail]) map[item.parent][item.detail] = [];
+                map[item.parent][item.detail].push(item);
+            });
+            for (const [parent, details] of Object.entries(map)) {
+                const parentDiv = document.createElement('div');
+                parentDiv.className = 'bg-white p-4 rounded-lg shadow';
+                const parentTitle = document.createElement('div');
+                parentTitle.textContent = parent;
+                parentTitle.className = 'font-bold mb-2';
+                parentDiv.appendChild(parentTitle);
+                for (const [detail, list] of Object.entries(details)) {
+                    const detailDiv = document.createElement('div');
+                    detailDiv.className = 'ml-4 mb-2';
+                    const detailTitle = document.createElement('div');
+                    detailTitle.textContent = detail;
+                    detailTitle.className = 'font-medium';
+                    detailDiv.appendChild(detailTitle);
+                    const ul = document.createElement('ul');
+                    ul.className = 'ml-4 list-disc text-gray-700';
+                    list.forEach(it => {
+                        const li = document.createElement('li');
+                        li.textContent = it.name;
+                        ul.appendChild(li);
+                    });
+                    detailDiv.appendChild(ul);
+                    parentDiv.appendChild(detailDiv);
+                }
+                container.appendChild(parentDiv);
+            }
+        }
+        document.addEventListener('DOMContentLoaded', renderMap);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a link to new storage map page
- implement `map.html` to visualize items by location

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bba8b9020832eae2d33365d9686f9