### PR TITLE
Add usage statistics view

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,10 +192,10 @@
                             <i class="fas fa-tags mr-3"></i>
                             QRコード管理
                         </button>
-                        <button class="w-full bg-orange-50 text-orange-700 p-3 rounded-lg hover:bg-orange-100 transition text-left">
+                        <a href="stats.html" class="block w-full bg-orange-50 text-orange-700 p-3 rounded-lg hover:bg-orange-100 transition text-left">
                             <i class="fas fa-chart-bar mr-3"></i>
                             利用統計
-                        </button>
+                        </a>
                         <a href="items.html" class="block w-full bg-teal-50 text-teal-700 p-3 rounded-lg hover:bg-teal-100 transition text-left">
                             <i class="fas fa-list mr-3"></i>
                             登録アイテム一覧

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>利用統計 - どこに置いたっけ？</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <style>
+        body { background: #f5f7fa; }
+    </style>
+</head>
+<body class="p-6">
+    <header class="mb-6">
+        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
+        <h1 class="text-2xl font-bold mt-2">利用統計</h1>
+    </header>
+    <div class="grid md:grid-cols-2 gap-6">
+        <div class="bg-white p-4 rounded-lg shadow">
+            <h2 class="font-medium mb-2">カテゴリー別アイテム数</h2>
+            <canvas id="itemsChart" height="200"></canvas>
+        </div>
+        <div class="bg-white p-4 rounded-lg shadow">
+            <h2 class="font-medium mb-2">直近7日間の検索回数</h2>
+            <canvas id="searchChart" height="200"></canvas>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="script.js"></script>
+    <script src="stats.js"></script>
+</body>
+</html>

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,60 @@
+function renderStats() {
+  const items = loadItems();
+  const history = loadHistory();
+
+  const itemCounts = {};
+  items.forEach(item => {
+    itemCounts[item.parent] = (itemCounts[item.parent] || 0) + 1;
+  });
+  const itemLabels = Object.keys(itemCounts);
+  const itemValues = Object.values(itemCounts);
+  new Chart(document.getElementById('itemsChart').getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels: itemLabels,
+      datasets: [{
+        label: 'アイテム数',
+        data: itemValues,
+        backgroundColor: '#4A90E2'
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+
+  const searchCounts = {};
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    searchCounts[d.toLocaleDateString()] = 0;
+  }
+  history.forEach(h => {
+    if (h.action === 'search') {
+      const key = new Date(h.timestamp).toLocaleDateString();
+      if (searchCounts[key] !== undefined) searchCounts[key]++;
+    }
+  });
+  const searchLabels = Object.keys(searchCounts);
+  const searchValues = Object.values(searchCounts);
+  new Chart(document.getElementById('searchChart').getContext('2d'), {
+    type: 'line',
+    data: {
+      labels: searchLabels,
+      datasets: [{
+        label: '検索回数',
+        data: searchValues,
+        backgroundColor: '#f6ad55',
+        borderColor: '#ed8936',
+        fill: false
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', renderStats);


### PR DESCRIPTION
## Summary
- show usage statistics page with Chart.js
- link to statistics from dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bba992ab0832e9effc520d3fde685