### PR TITLE
Add button to clear monthly search history

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,14 +94,17 @@
             </div>
             
             <div class="bg-white p-6 rounded-lg custom-shadow card-hover">
-                <div class="flex items-center">
-                    <div class="bg-orange-100 p-3 rounded-full">
-                        <i class="fas fa-search text-orange-600 text-xl"></i>
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center">
+                        <div class="bg-orange-100 p-3 rounded-full">
+                            <i class="fas fa-search text-orange-600 text-xl"></i>
+                        </div>
+                        <div class="ml-4">
+                            <p class="text-gray-600 text-sm">今月の検索</p>
+                            <p class="text-2xl font-bold text-gray-800" id="searchCount">0</p>
+                        </div>
                     </div>
-                    <div class="ml-4">
-                        <p class="text-gray-600 text-sm">今月の検索</p>
-                        <p class="text-2xl font-bold text-gray-800" id="searchCount">0</p>
-                    </div>
+                    <button id="clearMonthlySearch" class="text-red-500 text-sm hover:underline">削除</button>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -38,6 +38,18 @@ function updateDashboard() {
   document.getElementById('searchCount').textContent = searches.length;
 }
 
+function clearMonthlySearches() {
+  const now = new Date();
+  const month = now.getMonth();
+  const history = loadHistory();
+  const filtered = history.filter(
+    h => !(h.action === 'search' && new Date(h.timestamp).getMonth() === month)
+  );
+  saveHistory(filtered);
+  updateDashboard();
+  renderHistory();
+}
+
 function renderHistory() {
   const list = document.getElementById('activityList');
   list.innerHTML = '';
@@ -138,4 +150,12 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('cancelItem').addEventListener('click', () => {
     form.classList.add('hidden');
   });
+  const clearBtn = document.getElementById('clearMonthlySearch');
+  if (clearBtn) {
+    clearBtn.addEventListener('click', () => {
+      if (confirm('今月の検索履歴を削除しますか？')) {
+        clearMonthlySearches();
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- add `clearMonthlySearches` function in `script.js` and hook to dashboard button
- add button in `index.html` to clear this month’s search history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bbaaf1260832eaa607607a3ddfbe3