### PR TITLE
写真から登録機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
                     </button>
                     
                     <div class="mt-4 space-y-2">
-                        <button class="w-full bg-gray-100 text-gray-700 p-3 rounded-lg hover:bg-gray-200 transition text-sm">
+                        <button id="addFromPhoto" class="w-full bg-gray-100 text-gray-700 p-3 rounded-lg hover:bg-gray-200 transition text-sm" type="button">
                             <i class="fas fa-camera mr-2"></i>
                             写真から登録
                         </button>

--- a/script.js
+++ b/script.js
@@ -163,6 +163,15 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const photoInput = document.getElementById('itemPhoto');
   const dropArea = document.getElementById('photoDrop');
+
+  const addFromPhotoBtn = document.getElementById('addFromPhoto');
+  if (addFromPhotoBtn && form && photoInput) {
+    addFromPhotoBtn.addEventListener('click', () => {
+      form.classList.remove('hidden');
+      form.scrollIntoView({ behavior: 'smooth' });
+      photoInput.click();
+    });
+  }
   if (photoInput && dropArea) {
     photoInput.addEventListener('change', e => {
       if (e.target.files[0]) handlePhoto(e.target.files[0]);


### PR DESCRIPTION
## 概要
- ボタンに `addFromPhoto` ID を付与
- 写真から登録ボタン押下でフォームを表示しカメラ起動

## テスト
- `npm test` (テスト未実装のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_684bc27c8838832ea9eb4139b079173d