### PR TITLE
Fix mobile layout for photo upload

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
                         <label class="block text-gray-700 font-medium mb-2">
                             <i class="fas fa-camera mr-2"></i>写真
                         </label>
-                        <label id="photoDrop" class="cursor-pointer border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-blue-400 transition">
+                        <label id="photoDrop" class="block w-full cursor-pointer border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-blue-400 transition">
                             <input type="file" id="itemPhoto" accept="image/*" capture="environment" class="hidden">
                             <div id="photoPreview" class="flex flex-col items-center justify-center">
                                 <i class="fas fa-cloud-upload-alt text-gray-400 text-3xl mb-2"></i>

--- a/script.js
+++ b/script.js
@@ -144,7 +144,7 @@ function handlePhoto(file) {
       photoData = canvas.toDataURL('image/jpeg', 0.8);
       const preview = document.getElementById('photoPreview');
       if (preview) {
-        preview.innerHTML = `<img src="${photoData}" class="mx-auto mb-2 max-h-40 rounded-lg" alt="preview">`;
+        preview.innerHTML = `<img src="${photoData}" class="mx-auto mb-2 max-h-40 rounded-lg max-w-full" alt="preview">`;
       }
     };
     img.src = e.target.result;


### PR DESCRIPTION
## Summary
- make photo drop zone full width by default
- prevent photo preview image from overflowing on small screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c264f4f2c832eab64507d44f632b3