### PR TITLE
Add data export/import

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,15 @@
                             <i class="fas fa-folder-open mr-3"></i>
                             収納場所管理
                         </a>
+                        <button id="exportDataBtn" class="w-full bg-yellow-50 text-yellow-700 p-3 rounded-lg hover:bg-yellow-100 transition text-left">
+                            <i class="fas fa-download mr-3"></i>
+                            データエクスポート
+                        </button>
+                        <button id="importDataBtn" class="w-full bg-purple-50 text-purple-700 p-3 rounded-lg hover:bg-purple-100 transition text-left">
+                            <i class="fas fa-upload mr-3"></i>
+                            データインポート
+                        </button>
+                        <input type="file" id="importDataInput" accept="application/json" class="hidden">
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -152,6 +152,45 @@ function handlePhoto(file) {
   reader.readAsDataURL(file);
 }
 
+function exportData() {
+  const data = {
+    items: loadItems(),
+    locations: loadLocations()
+  };
+  const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'item-locator-data.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function importData(file) {
+  const reader = new FileReader();
+  reader.onload = e => {
+    try {
+      const data = JSON.parse(e.target.result);
+      if (Array.isArray(data.items) && Array.isArray(data.locations)) {
+        localStorage.setItem(ITEM_KEY, JSON.stringify(data.items));
+        localStorage.setItem(LOCATION_KEY, JSON.stringify(data.locations));
+        updateDashboard();
+        updateLocationOptions();
+        renderLocations();
+        if (typeof renderAllItems === 'function') renderAllItems();
+        alert('データをインポートしました');
+      } else {
+        alert('データ形式が不正です');
+      }
+    } catch (err) {
+      alert('データの読み込みに失敗しました');
+    }
+  };
+  reader.readAsText(file);
+}
+
 function saveItem() {
   const name = document.getElementById('itemName').value.trim();
   if (!name) return alert('アイテム名を入力してください');
@@ -380,6 +419,18 @@ window.addEventListener('DOMContentLoaded', () => {
       e.preventDefault();
       dropArea.classList.remove('border-blue-400');
       if (e.dataTransfer.files[0]) handlePhoto(e.dataTransfer.files[0]);
+    });
+  }
+
+  const exportBtn = document.getElementById('exportDataBtn');
+  if (exportBtn) exportBtn.addEventListener('click', exportData);
+  const importBtn = document.getElementById('importDataBtn');
+  const importInput = document.getElementById('importDataInput');
+  if (importBtn && importInput) {
+    importBtn.addEventListener('click', () => importInput.click());
+    importInput.addEventListener('change', e => {
+      if (e.target.files[0]) importData(e.target.files[0]);
+      importInput.value = '';
     });
   }
 });


### PR DESCRIPTION
## Summary
- add export/import buttons in quick actions
- implement `exportData` and `importData` in JS
- wire up new buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c305b2988832ebb186a8ca894aab4