### PR TITLE
Add responsive font size menu

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,3 +1,12 @@
-<header class="bg-gray-100 p-4 mb-6 flex justify-between items-center">
-  <a href="index.html" class="text-blue-600 font-bold text-lg">どこに置いたっけ？</a>
+<header class="bg-gray-100 p-4 mb-6">
+  <div class="flex justify-between items-center">
+    <a href="index.html" class="text-blue-600 font-bold text-lg">どこに置いたっけ？</a>
+    <div class="flex items-center gap-2">
+      <div id="desktopFontSize" class="hidden md:block"></div>
+      <button id="mobileMenuBtn" class="md:hidden px-2 text-2xl">&#9776;</button>
+    </div>
+  </div>
+  <div id="mobileMenu" class="md:hidden hidden mt-2">
+    <div id="mobileFontSize"></div>
+  </div>
 </header>

--- a/header.js
+++ b/header.js
@@ -17,5 +17,17 @@ async function loadCommonHeader() {
     }
   }
   initFontSizeControl();
+  initMobileMenu();
 }
+
+function initMobileMenu() {
+  const btn = document.getElementById('mobileMenuBtn');
+  const menu = document.getElementById('mobileMenu');
+  if (btn && menu) {
+    btn.addEventListener('click', () => {
+      menu.classList.toggle('hidden');
+    });
+  }
+}
+
 window.addEventListener('DOMContentLoaded', loadCommonHeader);

--- a/index.html
+++ b/index.html
@@ -45,10 +45,17 @@
                         <p class="text-blue-100">持ち物ロケーター</p>
                     </div>
                 </div>
-                <div class="text-right">
-                    <p class="text-blue-100">探し物の時間をゼロに！</p>
-                    <p class="text-sm">AIで賢く管理</p>
+                <div class="flex items-center space-x-4">
+                    <div class="text-right">
+                        <p class="text-blue-100">探し物の時間をゼロに！</p>
+                        <p class="text-sm">AIで賢く管理</p>
+                    </div>
+                    <div id="desktopFontSize" class="hidden md:block"></div>
+                    <button id="mobileMenuBtn" class="md:hidden text-2xl">&#9776;</button>
                 </div>
+            </div>
+            <div id="mobileMenu" class="md:hidden hidden mt-2">
+                <div id="mobileFontSize"></div>
             </div>
         </div>
     </header>

--- a/script.js
+++ b/script.js
@@ -20,31 +20,45 @@ function saveFontSize(size) {
 }
 
 function initFontSizeControl() {
-  const select = document.createElement('select');
-  select.id = 'fontSizeSelect';
-  // Remove fixed positioning so the control is placed in normal flow
-  select.className = 'p-2 border rounded bg-white shadow text-sm text-black';
-  const options = [
-    { v: '20', l: '特大' },
-    { v: '18', l: '大' },
-    { v: '16', l: '標準' },
-    { v: '14', l: '小' },
-    { v: '12', l: '極小' }
-  ];
-  options.forEach(o => {
-    const opt = document.createElement('option');
-    opt.value = o.v;
-    opt.textContent = o.l;
-    select.appendChild(opt);
-  });
-  const container = document.querySelector('header') || document.body;
-  container.appendChild(select);
+  const containers = [];
+  const desktop = document.getElementById('desktopFontSize');
+  const mobile = document.getElementById('mobileFontSize');
+  if (desktop) containers.push(desktop);
+  if (mobile) containers.push(mobile);
+  if (containers.length === 0) {
+    const header = document.querySelector('header');
+    if (header) containers.push(header);
+  }
+
+  const selects = [];
   const size = loadFontSize();
   applyFontSize(size);
-  select.value = size;
-  select.addEventListener('change', e => {
-    applyFontSize(e.target.value);
-    saveFontSize(e.target.value);
+
+  containers.forEach(c => {
+    const select = document.createElement('select');
+    select.className = 'p-2 border rounded bg-white shadow text-sm text-black';
+    const options = [
+      { v: '20', l: '特大' },
+      { v: '18', l: '大' },
+      { v: '16', l: '標準' },
+      { v: '14', l: '小' },
+      { v: '12', l: '極小' }
+    ];
+    options.forEach(o => {
+      const opt = document.createElement('option');
+      opt.value = o.v;
+      opt.textContent = o.l;
+      select.appendChild(opt);
+    });
+    select.value = size;
+    select.addEventListener('change', e => {
+      const val = e.target.value;
+      applyFontSize(val);
+      saveFontSize(val);
+      selects.forEach(s => { if (s !== e.target) s.value = val; });
+    });
+    c.appendChild(select);
+    selects.push(select);
   });
 }
 


### PR DESCRIPTION
## Summary
- add hamburger menu and desktop font size control
- hook up mobile menu toggle logic
- update font size script to sync between mobile and desktop controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684cd3b4e018832e99a48b6707611331