### PR TITLE
部屋選択プルダウン改善＆アイテム編集連携

### DIFF
--- a/items.html
+++ b/items.html
@@ -54,13 +54,15 @@
                 controls.className = 'ml-auto flex gap-2';
                 const editBtn = document.createElement('button');
                 editBtn.innerHTML = '<i class="fas fa-edit text-blue-500"></i>';
-                editBtn.addEventListener('click', () => editItem(item.id));
+                editBtn.addEventListener('click', e => { e.stopPropagation(); editItem(item.id); });
                 const delBtn = document.createElement('button');
                 delBtn.innerHTML = '<i class="fas fa-trash-alt text-red-500"></i>';
-                delBtn.addEventListener('click', () => deleteItem(item.id));
+                delBtn.addEventListener('click', e => { e.stopPropagation(); deleteItem(item.id); });
                 controls.appendChild(editBtn);
                 controls.appendChild(delBtn);
                 div.appendChild(controls);
+
+                div.addEventListener('click', () => editItem(item.id));
 
                 container.appendChild(div);
             });

--- a/script.js
+++ b/script.js
@@ -85,11 +85,16 @@ function saveLocations(locations) {
 }
 
 function updateRoomOptions() {
-  const select = document.getElementById('roomSelect');
-  if (!select) return;
+  const selects = [
+    document.getElementById('roomSelect'),
+    document.getElementById('locationRoomSelect')
+  ].filter(Boolean);
+  if (selects.length === 0) return;
   const rooms = loadRooms();
-  select.innerHTML = '<option>選択してください</option>' +
-    rooms.map(r => `<option>${r}</option>`).join('');
+  selects.forEach(select => {
+    select.innerHTML = '<option>選択してください</option>' +
+      rooms.map(r => `<option>${r}</option>`).join('');
+  });
 }
 
 function updateLocationOptions(room) {


### PR DESCRIPTION
## Summary
- 部屋管理ページで登録済みの部屋が選択できない問題を修正
- アイテム一覧でボックスをクリックすると編集画面（プロンプト）を開くよう改善

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684cf733e3d4832eaab9bf867f2edb7f