### PR TITLE
Add simple layout map

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,11 @@
                         <a href="map.html" class="block w-full bg-blue-50 text-blue-700 p-3 rounded-lg hover:bg-blue-100 transition text-left">
                             <i class="fas fa-map mr-3"></i>
                             収納マップ
-                        </button>
+                        </a>
+                        <a href="layout.html" class="block w-full bg-blue-50 text-blue-700 p-3 rounded-lg hover:bg-blue-100 transition text-left">
+                            <i class="fas fa-th mr-3"></i>
+                            配置マップ
+                        </a>
                         <a href="items.html" class="block w-full bg-teal-50 text-teal-700 p-3 rounded-lg hover:bg-teal-100 transition text-left">
                             <i class="fas fa-list mr-3"></i>
                             登録アイテム一覧

--- a/layout.html
+++ b/layout.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>収納配置マップ - どこに置いたっけ？</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <style>
+        body { background: #f5f7fa; }
+        .room { width: 300px; height: 200px; }
+        .location { width: 80px; height: 40px; }
+    </style>
+</head>
+<body class="p-6">
+    <header class="mb-6">
+        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
+        <h1 class="text-2xl font-bold mt-2">収納配置マップ</h1>
+    </header>
+    <div id="layout" class="flex flex-wrap gap-6"></div>
+    <script src="script.js"></script>
+    <script src="layout.js"></script>
+    <script src="header.js"></script>
+</body>
+</html>

--- a/layout.js
+++ b/layout.js
@@ -1,0 +1,65 @@
+function saveLayout() {
+  saveLocations(window.layoutLocations);
+}
+
+function createLocationBox(loc, roomDiv) {
+  const box = document.createElement('div');
+  box.className = 'location absolute bg-blue-100 border border-blue-300 text-xs flex items-center justify-center cursor-move rounded';
+  box.textContent = loc.name;
+  loc.x = loc.x || 10;
+  loc.y = loc.y || 10;
+  box.style.left = loc.x + 'px';
+  box.style.top = loc.y + 'px';
+  roomDiv.appendChild(box);
+
+  box.addEventListener('mousedown', e => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const origX = loc.x;
+    const origY = loc.y;
+    function onMove(ev) {
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      let x = origX + dx;
+      let y = origY + dy;
+      x = Math.max(0, Math.min(roomDiv.clientWidth - box.offsetWidth, x));
+      y = Math.max(0, Math.min(roomDiv.clientHeight - box.offsetHeight, y));
+      box.style.left = x + 'px';
+      box.style.top = y + 'px';
+      loc.x = x;
+      loc.y = y;
+    }
+    function endMove() {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', endMove);
+      saveLayout();
+    }
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', endMove);
+  });
+}
+
+function initLayout() {
+  const container = document.getElementById('layout');
+  const rooms = loadRooms();
+  const locations = loadLocations();
+  window.layoutLocations = locations;
+  container.innerHTML = '';
+  rooms.forEach(room => {
+    const div = document.createElement('div');
+    div.className = 'room border border-gray-300 bg-white rounded relative';
+    div.dataset.room = room;
+    const title = document.createElement('div');
+    title.textContent = room;
+    title.className = 'bg-gray-100 text-sm px-2 py-1';
+    div.appendChild(title);
+    container.appendChild(div);
+  });
+  locations.forEach(loc => {
+    const roomDiv = container.querySelector(`.room[data-room="${loc.room}"]`);
+    if (roomDiv) createLocationBox(loc, roomDiv);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initLayout);


### PR DESCRIPTION
## Summary
- add new **layout.html** with 2D placement UI
- implement drag and drop logic in **layout.js**
- link to the layout page from the index

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dddf40390832e9f86f54de3cf5a19