### PR TITLE
Add layout map on top page

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,6 +301,15 @@
             </div>
         </div>
 
+        <!-- 収納配置マップ -->
+        <div class="bg-white p-6 rounded-lg custom-shadow mb-8">
+            <h2 class="text-xl font-bold text-gray-800 mb-4 flex items-center">
+                <i class="fas fa-th mr-2"></i>
+                収納配置マップ
+            </h2>
+            <div id="layout" class="flex flex-wrap gap-6"></div>
+        </div>
+
         <!-- おすすめ収納グッズ -->
         <div class="bg-white p-6 rounded-lg custom-shadow mb-8">
             <h2 class="text-xl font-bold text-gray-800 mb-2 flex items-center">
@@ -385,6 +394,7 @@
 </footer>
     </div>
     <script src="script.js"></script>
+    <script src="layout.js"></script>
     <script src="header.js"></script>
     <script>
         if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- show 2D layout map on top page
- include layout.js script on index

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684de07c38d8832e921fcd3e9072fd41