### PR TITLE
Enable touch drag for layout map

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -9,7 +9,7 @@
     <style>
         body { background: #f5f7fa; }
         .room { width: 300px; height: 200px; }
-        .location { width: 80px; height: 40px; }
+        .location { width: 80px; height: 40px; touch-action: none; }
     </style>
 </head>
 <body class="p-6">

--- a/layout.js
+++ b/layout.js
@@ -12,15 +12,14 @@ function createLocationBox(loc, roomDiv) {
   box.style.top = loc.y + 'px';
   roomDiv.appendChild(box);
 
-  box.addEventListener('mousedown', e => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startY = e.clientY;
+  function startDrag(startX, startY, isTouch) {
     const origX = loc.x;
     const origY = loc.y;
     function onMove(ev) {
-      const dx = ev.clientX - startX;
-      const dy = ev.clientY - startY;
+      const clientX = isTouch ? ev.touches[0].clientX : ev.clientX;
+      const clientY = isTouch ? ev.touches[0].clientY : ev.clientY;
+      const dx = clientX - startX;
+      const dy = clientY - startY;
       let x = origX + dx;
       let y = origY + dy;
       x = Math.max(0, Math.min(roomDiv.clientWidth - box.offsetWidth, x));
@@ -31,12 +30,23 @@ function createLocationBox(loc, roomDiv) {
       loc.y = y;
     }
     function endMove() {
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', endMove);
+      document.removeEventListener(isTouch ? 'touchmove' : 'mousemove', onMove);
+      document.removeEventListener(isTouch ? 'touchend' : 'mouseup', endMove);
       saveLayout();
     }
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', endMove);
+    document.addEventListener(isTouch ? 'touchmove' : 'mousemove', onMove);
+    document.addEventListener(isTouch ? 'touchend' : 'mouseup', endMove);
+  }
+
+  box.addEventListener('mousedown', e => {
+    e.preventDefault();
+    startDrag(e.clientX, e.clientY, false);
+  });
+
+  box.addEventListener('touchstart', e => {
+    e.preventDefault();
+    const t = e.touches[0];
+    startDrag(t.clientX, t.clientY, true);
   });
 }
 


### PR DESCRIPTION
## Summary
- enable dragging of location boxes on mobile via touch events
- disable browser panning while dragging with `touch-action: none`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684de353cd08832eae4d55344b5bbf18