### PR TITLE
ヘッダーを共通テンプレート化

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,27 +34,7 @@
     </style>
 </head>
 <body class="bg-gray-50 font-sans">
-    <!-- ヘッダー -->
-    <header class="gradient-bg text-white p-6 custom-shadow">
-        <div class="max-w-6xl mx-auto">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-3">
-                    <i class="fas fa-map-marker-alt text-3xl"></i>
-                    <div>
-                        <h1 class="text-2xl font-bold">どこに置いたっけ？</h1>
-                        <p class="text-blue-100">持ち物ロケーター</p>
-                    </div>
-                </div>
-                <div class="flex items-center space-x-4">
-                    <div class="text-right">
-                        <p class="text-blue-100">探し物の時間をゼロに！</p>
-                        <p class="text-sm">AIで賢く管理</p>
-                    </div>
-                    <div id="fontSize"></div>
-                </div>
-            </div>
-        </div>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
 
     <div class="max-w-6xl mx-auto p-6">
         <!-- ダッシュボード統計 -->

--- a/items.html
+++ b/items.html
@@ -11,14 +11,11 @@
     </style>
 </head>
 <body class="p-6">
-    <header class="mb-6">
-        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
-        <h1 class="text-2xl font-bold mt-2 mb-4">登録アイテム一覧</h1>
-        <form id="itemsSearchForm" action="items.html" method="get" class="flex max-w-md">
-            <input id="itemsSearchInput" name="q" type="text" placeholder="アイテム名、場所、タグで検索..." class="flex-grow p-2 border border-gray-300 rounded-l-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent">
-            <button type="submit" id="itemsSearchBtn" class="bg-blue-600 text-white px-4 rounded-r-lg hover:bg-blue-700 transition"><i class="fas fa-search"></i></button>
-        </form>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
+    <form id="itemsSearchForm" action="items.html" method="get" class="flex max-w-md mb-6">
+        <input id="itemsSearchInput" name="q" type="text" placeholder="アイテム名、場所、タグで検索..." class="flex-grow p-2 border border-gray-300 rounded-l-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent">
+        <button type="submit" id="itemsSearchBtn" class="bg-blue-600 text-white px-4 rounded-r-lg hover:bg-blue-700 transition"><i class="fas fa-search"></i></button>
+    </form>
     <div id="itemsList" class="space-y-3"></div>
 
     <!-- 編集フォーム -->

--- a/layout.html
+++ b/layout.html
@@ -13,10 +13,7 @@
     </style>
 </head>
 <body class="p-6">
-    <header class="mb-6">
-        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
-        <h1 class="text-2xl font-bold mt-2">収納配置マップ</h1>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
     <div id="layout" class="flex flex-wrap gap-6"></div>
     <script src="script.js"></script>
     <script src="layout.js"></script>

--- a/locations.html
+++ b/locations.html
@@ -9,10 +9,7 @@
     <style>body { background: #f5f7fa; }</style>
 </head>
 <body class="p-6">
-    <header class="mb-6">
-        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
-        <h1 class="text-2xl font-bold mt-2">収納場所管理</h1>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
     <div class="mb-4 flex flex-col gap-2 sm:flex-row">
         <select id="locationRoomSelect" class="p-2 border border-gray-300 rounded-lg">
             <option>部屋を選択</option>

--- a/map.html
+++ b/map.html
@@ -11,10 +11,7 @@
     </style>
 </head>
 <body class="p-6">
-    <header class="mb-6">
-        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
-        <h1 class="text-2xl font-bold mt-2">収納マップ</h1>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
     <div id="floorPlan" class="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6"></div>
     <div id="mapContainer" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"></div>
     <script src="script.js"></script>

--- a/rooms.html
+++ b/rooms.html
@@ -9,10 +9,7 @@
     <style>body { background: #f5f7fa; }</style>
 </head>
 <body class="p-6">
-    <header class="mb-6">
-        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
-        <h1 class="text-2xl font-bold mt-2">収納部屋管理</h1>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
     <div class="mb-4 flex gap-2">
         <input id="newRoomName" type="text" placeholder="部屋名" class="p-2 border border-gray-300 rounded-lg flex-grow">
         <button id="addRoomBtn" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition">追加</button>

--- a/stats.html
+++ b/stats.html
@@ -11,10 +11,7 @@
     </style>
 </head>
 <body class="p-6">
-    <header class="mb-6">
-        <a href="index.html" class="text-blue-600 hover:underline"><i class="fas fa-arrow-left mr-2"></i>戻る</a>
-        <h1 class="text-2xl font-bold mt-2">利用統計</h1>
-    </header>
+    <!-- ヘッダーは共通テンプレートから読み込み -->
     <div class="grid md:grid-cols-2 gap-6">
         <div class="bg-white p-4 rounded-lg shadow">
             <h2 class="font-medium mb-2">カテゴリー別アイテム数</h2>


### PR DESCRIPTION
## Summary
- ヘッダーを各ページから削除し、`header.html` を読み込む方式に統一
- `index.html` など7ページを更新

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684de6703610832ebf909103cdb06ad5