### PR TITLE
収納場所編集フォームの追加

### DIFF
--- a/locations.html
+++ b/locations.html
@@ -17,6 +17,18 @@
         <input id="newLocationName" type="text" placeholder="収納場所名" class="p-2 border border-gray-300 rounded-lg flex-grow">
         <button id="addLocationBtn" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition">追加</button>
     </div>
+
+    <!-- 編集フォーム -->
+    <div id="editLocationForm" class="mb-4 flex flex-col gap-2 sm:flex-row hidden">
+        <select id="editLocationRoom" class="p-2 border border-gray-300 rounded-lg">
+            <option>部屋を選択</option>
+        </select>
+        <input id="editLocationName" type="text" placeholder="収納場所名" class="p-2 border border-gray-300 rounded-lg flex-grow">
+        <div class="flex gap-2">
+            <button id="saveEditLocationBtn" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition">保存</button>
+            <button id="cancelEditLocationBtn" class="bg-gray-300 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-400 transition">キャンセル</button>
+        </div>
+    </div>
     <div id="locationsList" class="space-y-3"></div>
     <script src="script.js"></script>
     <script src="header.js"></script>
@@ -24,8 +36,12 @@
         document.addEventListener('DOMContentLoaded', () => {
             updateRoomOptions();
             renderLocations();
-            const btn = document.getElementById('addLocationBtn');
-            if (btn) btn.addEventListener('click', addLocation);
+            const addBtn = document.getElementById('addLocationBtn');
+            if (addBtn) addBtn.addEventListener('click', addLocation);
+            const saveBtn = document.getElementById('saveEditLocationBtn');
+            if (saveBtn) saveBtn.addEventListener('click', saveEditLocation);
+            const cancelBtn = document.getElementById('cancelEditLocationBtn');
+            if (cancelBtn) cancelBtn.addEventListener('click', cancelEditLocation);
         });
     </script>
 </body>


### PR DESCRIPTION
## 概要
- 収納場所をフォームから編集できるようにしました
- rooms の選択肢更新に編集用セレクトを追加
- 編集開始・保存・キャンセル処理を実装

## テスト
- `npm test` を実行し、テストが未定義のため失敗することを確認

------
https://chatgpt.com/codex/tasks/task_e_684df14cea84832e981ea31a78d5f72c