### PR TITLE
Improve layout map interactions and sticky header

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,4 +1,4 @@
-<header class="bg-gray-100 p-4 mb-6">
+<header class="bg-gray-100 p-4 mb-6 fixed w-full top-0 left-0 z-50">
   <style>
     #navMenu {
       display: none;

--- a/header.js
+++ b/header.js
@@ -17,6 +17,10 @@ async function loadCommonHeader() {
     }
   }
   initFontSizeControl();
+  const headerElem = document.querySelector('header');
+  if (headerElem) {
+    document.body.style.paddingTop = headerElem.offsetHeight + 'px';
+  }
   const toggle = document.getElementById('menuToggle');
   const menu = document.getElementById('navMenu');
   if (toggle && menu) {

--- a/items.html
+++ b/items.html
@@ -134,14 +134,21 @@
     <script src="script.js"></script>
     <script src="header.js"></script>
     <script>
-        function renderAllItems(query = '') {
+        function renderAllItems(query = '', loc = '') {
             const container = document.getElementById('itemsList');
             const items = loadItems();
             const keywords = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
-            const filtered = keywords.length ? items.filter(item => {
-                const text = [item.name, item.memo, formatLocation(item), item.tags.join(' ')].join(' ').toLowerCase();
-                return keywords.every(k => text.includes(k));
-            }) : items;
+            let filtered = items;
+            if (loc) {
+                const parts = loc.split('/');
+                filtered = filtered.filter(item => parts.every((p, i) => item.locationPath[i] === p));
+            }
+            if (keywords.length) {
+                filtered = filtered.filter(item => {
+                    const text = [item.name, item.memo, formatLocation(item), item.tags.join(' ')].join(' ').toLowerCase();
+                    return keywords.every(k => text.includes(k));
+                });
+            }
             container.innerHTML = '';
             if (filtered.length === 0) {
                 container.innerHTML = '<p class="text-gray-600">該当するアイテムがありません。</p>';
@@ -181,12 +188,13 @@
         document.addEventListener('DOMContentLoaded', () => {
             const params = new URLSearchParams(location.search);
             const q = params.get('q') || '';
+            const loc = params.get('loc') || '';
             const input = document.getElementById('itemsSearchInput');
             if (input) {
                 input.value = q;
-                input.addEventListener('input', e => renderAllItems(e.target.value));
+                input.addEventListener('input', e => renderAllItems(e.target.value, loc));
             }
-            renderAllItems(q);
+            renderAllItems(q, loc);
         });
     </script>
 </body>

--- a/layout.js
+++ b/layout.js
@@ -12,6 +12,7 @@ function createLocationBox(loc, roomDiv) {
   box.style.top = loc.y + 'px';
   roomDiv.appendChild(box);
 
+  let moved = false;
   function startDrag(startX, startY, isTouch) {
     const origX = loc.x;
     const origY = loc.y;
@@ -28,6 +29,7 @@ function createLocationBox(loc, roomDiv) {
       box.style.top = y + 'px';
       loc.x = x;
       loc.y = y;
+      moved = true;
     }
     function endMove() {
       document.removeEventListener(isTouch ? 'touchmove' : 'mousemove', onMove);
@@ -40,13 +42,22 @@ function createLocationBox(loc, roomDiv) {
 
   box.addEventListener('mousedown', e => {
     e.preventDefault();
+    moved = false;
     startDrag(e.clientX, e.clientY, false);
   });
 
   box.addEventListener('touchstart', e => {
     e.preventDefault();
     const t = e.touches[0];
+    moved = false;
     startDrag(t.clientX, t.clientY, true);
+  });
+
+  box.addEventListener('click', () => {
+    if (!moved) {
+      const path = encodeURIComponent(`${loc.room}/${loc.name}`);
+      location.href = `items.html?loc=${path}`;
+    }
   });
 }
 
@@ -54,6 +65,12 @@ function initLayout() {
   const container = document.getElementById('layout');
   const rooms = loadRooms();
   const locations = loadLocations();
+  rooms.sort((a, b) => {
+    const hasA = locations.some(l => l.room === a);
+    const hasB = locations.some(l => l.room === b);
+    if (hasA === hasB) return 0;
+    return hasA ? -1 : 1;
+  });
   window.layoutLocations = locations;
   container.innerHTML = '';
   rooms.forEach(room => {


### PR DESCRIPTION
## Summary
- fix header to be shown on top of every page
- keep pages visible by adding body padding dynamically
- sort rooms with configured locations first in layout map
- allow clicking a location box to view items in that spot
- filter item list by storage location when `loc` query is given

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684df43a7e54832e81480d3aa1f6fccd