### PR TITLE
Enable room-specific layout view from storage map

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -62,6 +62,9 @@ function createLocationBox(loc, roomDiv) {
 }
 
 function initLayout() {
+  const params = new URLSearchParams(location.search);
+  const filterRoom = params.get('room');
+
   const container = document.getElementById('layout');
   const rooms = loadRooms();
   const locations = loadLocations();
@@ -74,6 +77,7 @@ function initLayout() {
   window.layoutLocations = locations;
   container.innerHTML = '';
   rooms.forEach(room => {
+    if (filterRoom && room !== filterRoom) return;
     const div = document.createElement('div');
     div.className = 'room border border-gray-300 bg-white rounded relative';
     div.dataset.room = room;
@@ -84,6 +88,7 @@ function initLayout() {
     container.appendChild(div);
   });
   locations.forEach(loc => {
+    if (filterRoom && loc.room !== filterRoom) return;
     const roomDiv = container.querySelector(`.room[data-room="${loc.room}"]`);
     if (roomDiv) createLocationBox(loc, roomDiv);
   });

--- a/map.html
+++ b/map.html
@@ -76,8 +76,8 @@
                 cell.className = 'flex flex-col items-center p-4 bg-white rounded-lg shadow cursor-pointer hover:bg-blue-50';
                 cell.innerHTML = `<i class="fas fa-box-open text-2xl mb-2"></i><span>${parent}</span>`;
                 cell.addEventListener('click', () => {
-                    const section = document.getElementById('sec-' + parent);
-                    if (section) section.scrollIntoView({ behavior: 'smooth' });
+                    const room = encodeURIComponent(parent);
+                    location.href = `layout.html?room=${room}`;
                 });
                 floor.appendChild(cell);
             });


### PR DESCRIPTION
## Summary
- open `layout.html` filtered by room when clicking a room cell on `map.html`
- support `?room=` query param in `layout.js` to show a single room

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684df9544898832eb7454f312a4bae95