### PR TITLE
Add location input on layout view and compress empty rooms

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -9,11 +9,19 @@
     <style>
         body { background: #f5f7fa; }
         .room { width: 300px; height: 200px; }
+        .room.empty { width: 150px; height: 50px; display:flex; align-items:center; justify-content:center; }
         .location { width: 80px; height: 40px; touch-action: none; }
     </style>
 </head>
 <body class="p-6">
     <!-- ヘッダーは共通テンプレートから読み込み -->
+    <div class="mb-4 flex flex-col gap-2 sm:flex-row">
+        <select id="locationRoomSelect" class="p-2 border border-gray-300 rounded-lg">
+            <option>部屋を選択</option>
+        </select>
+        <input id="newLocationName" type="text" placeholder="収納場所名" class="p-2 border border-gray-300 rounded-lg flex-grow">
+        <button id="addLocationBtn" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition">追加</button>
+    </div>
     <div id="layout" class="flex flex-wrap gap-6"></div>
     <script src="script.js"></script>
     <script src="layout.js"></script>

--- a/layout.js
+++ b/layout.js
@@ -78,13 +78,19 @@ function initLayout() {
   container.innerHTML = '';
   rooms.forEach(room => {
     if (filterRoom && room !== filterRoom) return;
+    const hasLoc = locations.some(l => l.room === room);
     const div = document.createElement('div');
-    div.className = 'room border border-gray-300 bg-white rounded relative';
     div.dataset.room = room;
-    const title = document.createElement('div');
-    title.textContent = room;
-    title.className = 'bg-gray-100 text-sm px-2 py-1';
-    div.appendChild(title);
+    if (hasLoc) {
+      div.className = 'room border border-gray-300 bg-white rounded relative';
+      const title = document.createElement('div');
+      title.textContent = room;
+      title.className = 'bg-gray-100 text-sm px-2 py-1';
+      div.appendChild(title);
+    } else {
+      div.className = 'room empty border border-gray-300 bg-white rounded text-sm';
+      div.textContent = room;
+    }
     container.appendChild(div);
   });
   locations.forEach(loc => {
@@ -94,4 +100,8 @@ function initLayout() {
   });
 }
 
-document.addEventListener('DOMContentLoaded', initLayout);
+document.addEventListener('DOMContentLoaded', () => {
+  initLayout();
+  const btn = document.getElementById('addLocationBtn');
+  if (btn) btn.addEventListener('click', () => setTimeout(initLayout, 0));
+});


### PR DESCRIPTION
## Summary
- allow adding locations directly from the layout map page
- show compact boxes for rooms with no registered locations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684dfbb35f04832ea28e5ad93e127a71