### PR TITLE
Add room dropdown filter for layout map

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,6 +283,9 @@
                 <i class="fas fa-th mr-2"></i>
                 収納配置マップ
             </h2>
+            <select id="layoutRoomSelect" class="mb-4 p-2 border border-gray-300 rounded">
+                <option value="">選択してください</option>
+            </select>
             <div id="layout" class="flex flex-wrap gap-6"></div>
         </div>
 

--- a/layout.js
+++ b/layout.js
@@ -61,9 +61,9 @@ function createLocationBox(loc, roomDiv) {
   });
 }
 
-function initLayout() {
+function initLayout(selectedRoom) {
   const params = new URLSearchParams(location.search);
-  const filterRoom = params.get('room');
+  const filterRoom = selectedRoom !== undefined ? selectedRoom : params.get('room');
 
   const container = document.getElementById('layout');
   const rooms = loadRooms();
@@ -101,7 +101,15 @@ function initLayout() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  initLayout();
+  const roomSelect = document.getElementById('layoutRoomSelect');
+  if (roomSelect) {
+    initLayout(roomSelect.value || null);
+    roomSelect.addEventListener('change', e => initLayout(e.target.value || null));
+  } else {
+    initLayout();
+  }
   const btn = document.getElementById('addLocationBtn');
-  if (btn) btn.addEventListener('click', () => setTimeout(initLayout, 0));
+  if (btn) btn.addEventListener('click', () => setTimeout(() => {
+    initLayout(roomSelect ? roomSelect.value || null : undefined);
+  }, 0));
 });

--- a/script.js
+++ b/script.js
@@ -90,7 +90,8 @@ function updateRoomOptions() {
   const selects = [
     document.getElementById('roomSelect'),
     document.getElementById('locationRoomSelect'),
-    document.getElementById('editLocationRoom')
+    document.getElementById('editLocationRoom'),
+    document.getElementById('layoutRoomSelect')
   ].filter(Boolean);
   if (selects.length === 0) return;
   const rooms = loadRooms();
@@ -580,6 +581,11 @@ window.addEventListener('DOMContentLoaded', () => {
   updateLocationOptions(roomSelect ? roomSelect.value : '');
   renderLocations();
   renderRooms();
+  const layoutRoomSelect = document.getElementById('layoutRoomSelect');
+  if (layoutRoomSelect) {
+    const rooms = loadRooms();
+    if (rooms.length) layoutRoomSelect.value = rooms[0];
+  }
   const addRoomBtn = document.getElementById('addRoomBtn');
   if (addRoomBtn) addRoomBtn.addEventListener('click', addRoom);
   if (roomSelect) roomSelect.addEventListener('change', e => updateLocationOptions(e.target.value));


### PR DESCRIPTION
## Summary
- filter the layout map by selected room from dropdown on index
- allow layout.js to receive selected room parameter
- update room option generation to support the new dropdown

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e1171d344832e8b1673837c1490aa